### PR TITLE
Remove YARPC headers

### DIFF
--- a/internal/internal_utils.go
+++ b/internal/internal_utils.go
@@ -70,10 +70,6 @@ var (
 		libraryVersionHeaderName: LibraryVersion,
 		featureVersionHeaderName: FeatureVersion,
 		clientImplHeaderName:     clientImplHeaderValue,
-		// TODO: remove these headers when server is vanilla gRPC (not YARPC)
-		"rpc-caller":   "temporal-go-client",
-		"rpc-service":  "cadence-frontend",
-		"rpc-encoding": "proto",
 	})
 )
 


### PR DESCRIPTION
Since server is on vanilla gRPC now, YARPC headers are not needed.