### PR TITLE
Added workflow.AwaitWithTimeout

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/gogo/status v1.1.0/go.mod h1:BFv9nrluPLmrS0EmGVvLaPNmRosr9KapBYd5/hpY
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.4.0 h1:Rd1kQnQu0Hq3qvJppYSG0HtP+f5LPPUiDswTLiEegLg=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=

--- a/internal/internal_coroutines_test.go
+++ b/internal/internal_coroutines_test.go
@@ -692,7 +692,7 @@ func TestPanic(t *testing.T) {
 func TestAwait(t *testing.T) {
 	flag := false
 	d, _ := newDispatcher(createRootTestContext(), func(ctx Context) {
-		Await(ctx, func() bool { return flag })
+		_ = Await(ctx, func() bool { return flag })
 	})
 	err := d.ExecuteUntilAllBlocked()
 	require.NoError(t, err)

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2847,7 +2847,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_AwaitWithTimeoutTimeout() {
 	env.ExecuteWorkflow(workflowFn)
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
-	var result bool = true
-	env.GetWorkflowResult(&result)
+	result := true
+	_ = env.GetWorkflowResult(&result)
 	s.False(result)
 }

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2836,3 +2836,18 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityDeadlineExceeded() {
 	s.NoError(err)
 	s.Equal("context deadline exceeded", details)
 }
+
+func (s *WorkflowTestSuiteUnitTest) Test_AwaitWithTimeoutTimeout() {
+	workflowFn := func(ctx Context) (bool, error) {
+		return AwaitWithTimeout(ctx, time.Second, func() bool { return false })
+	}
+
+	RegisterWorkflow(workflowFn)
+	env := s.NewTestWorkflowEnvironment()
+	env.ExecuteWorkflow(workflowFn)
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	var result bool = true
+	env.GetWorkflowResult(&result)
+	s.False(result)
+}

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -282,8 +282,6 @@ func Await(ctx Context, condition func() bool) error {
 	return nil
 }
 
-var start time.Time = time.Now()
-
 // AwaitWithTimeout blocks the calling thread until condition() returns true
 // Returns ok equals to false if timed out and err equals to CanceledError if the ctx is canceled.
 func AwaitWithTimeout(ctx Context, timeout time.Duration, condition func() bool) (ok bool, err error) {

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -282,6 +282,30 @@ func Await(ctx Context, condition func() bool) error {
 	return nil
 }
 
+var start time.Time = time.Now()
+
+// AwaitWithTimeout blocks the calling thread until condition() returns true
+// Returns ok equals to false if timed out and err equals to CanceledError if the ctx is canceled.
+func AwaitWithTimeout(ctx Context, timeout time.Duration, condition func() bool) (ok bool, err error) {
+	state := getState(ctx)
+	defer state.unblocked()
+	timer := NewTimer(ctx, timeout)
+	for !condition() {
+		doneCh := ctx.Done()
+		// TODO: Consider always returning a channel
+		if doneCh != nil {
+			if _, more := doneCh.ReceiveAsyncWithMoreFlag(nil); !more {
+				return false, NewCanceledError("AwaitWithTimeout context cancelled")
+			}
+		}
+		if timer.IsReady() {
+			return false, nil
+		}
+		state.yield("AwaitWithTimeout")
+	}
+	return true, nil
+}
+
 // NewChannel create new Channel instance
 func NewChannel(ctx Context) Channel {
 	state := getState(ctx)

--- a/workflow/deterministic_wrappers.go
+++ b/workflow/deterministic_wrappers.go
@@ -60,6 +60,20 @@ func Await(ctx Context, condition func() bool) error {
 	return internal.Await(ctx, condition)
 }
 
+// AwaitWithTimeout blocks the calling thread until condition() returns true
+// or blocking time exceeds the passed timeout value
+// Returns ok equals to false if timed out and err equals to
+// CanceledError if the ctx is canceled.
+// The following code is going to block until the captured count
+// variable is set to 5 or one hour passes.
+//
+// workflow.AwaitWithTimeout(ctx, time.Hour, func() bool {
+//   return count == 5
+// })
+func AwaitWithTimeout(ctx Context, timeout time.Duration, condition func() bool) (ok bool, err error) {
+	return internal.AwaitWithTimeout(ctx, timeout, condition)
+}
+
 // NewChannel create new Channel instance
 func NewChannel(ctx Context) Channel {
 	return internal.NewChannel(ctx)


### PR DESCRIPTION
Added `workflow.AwaitWithTimeout` which allows to wait for a condition up to specified timeout.

Added back `TestAwait` and `TestAwaitCancellation` unit tests that got missing during a merge.
Added `TestAwaitWithTimeoutNoTimeout`, `TestAwaitWithTimeoutCancellation` and `Test_AwaitWithTimeoutTimeout` unit test.