### PR TITLE
Switch to serviceerror package

### DIFF
--- a/evictiontest/workflow_cache_eviction_test.go
+++ b/evictiontest/workflow_cache_eviction_test.go
@@ -29,22 +29,20 @@
 package evictiontest
 
 import (
-	"testing"
-
 	"strconv"
+	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/atomic"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc"
-
 	commonproto "go.temporal.io/temporal-proto/common"
 	"go.temporal.io/temporal-proto/enums"
 	"go.temporal.io/temporal-proto/workflowservice"
 	"go.temporal.io/temporal-proto/workflowservicemock"
+	"go.uber.org/atomic"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 
 	"go.temporal.io/temporal/internal"
 	"go.temporal.io/temporal/worker"

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/uber-go/tally v3.3.13+incompatible
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
-	go.temporal.io/temporal-proto v0.0.0-20200207215554-ecd0f5ea1703
+	go.temporal.io/temporal-proto v0.0.0-20200220011422-f48cb2702adc
 	go.uber.org/atomic v1.5.1
 	go.uber.org/goleak v0.10.0
 	go.uber.org/multierr v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/uber/jaeger-client-go v2.22.1+incompatible h1:NHcubEkVbahf9t3p75TOCR8
 github.com/uber/jaeger-client-go v2.22.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
-go.temporal.io/temporal-proto v0.0.0-20200207215554-ecd0f5ea1703 h1:AQ2wfE06D9yxR7etg35diiW9GrZHQSIHZiNY9dGfKs4=
-go.temporal.io/temporal-proto v0.0.0-20200207215554-ecd0f5ea1703/go.mod h1:SszgPhzKZvtDenZxaN68OKKj1RD1uVmDOHUn1RnTctk=
+go.temporal.io/temporal-proto v0.0.0-20200220011422-f48cb2702adc h1:68PyU/2L6jHNXfoXQbi/pTDQ3/HO8O8ReBb6x23grQY=
+go.temporal.io/temporal-proto v0.0.0-20200220011422-f48cb2702adc/go.mod h1:SszgPhzKZvtDenZxaN68OKKj1RD1uVmDOHUn1RnTctk=
 go.uber.org/atomic v1.5.0 h1:OI5t8sDa1Or+q8AeE+yKeB/SDYioSHAgcVljj9JIETY=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.5.1 h1:rsqfU5vBkVknbhUGbAUwQKR2H4ItV8tjJ+6kJX4cxHM=

--- a/internal/activity_test.go
+++ b/internal/activity_test.go
@@ -25,17 +25,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/gogo/status"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.temporal.io/temporal-proto/serviceerror"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 
 	"go.temporal.io/temporal-proto/workflowservice"
 	"go.temporal.io/temporal-proto/workflowservicemock"
-
-	"go.temporal.io/temporal/internal/common/rpc"
 )
 
 type activityTestSuite struct {
@@ -60,7 +57,7 @@ func (s *activityTestSuite) TearDownTest() {
 
 func (s *activityTestSuite) TestActivityHeartbeat() {
 	ctx, cancel := context.WithCancel(context.Background())
-	invoker := newServiceInvoker([]byte("task-token"), "identity", rpc.NewWorkflowServiceErrorWrapper(s.service), cancel, 1, make(chan struct{}))
+	invoker := newServiceInvoker([]byte("task-token"), "identity", s.service, cancel, 1, make(chan struct{}))
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{serviceInvoker: invoker})
 
 	s.service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -71,13 +68,13 @@ func (s *activityTestSuite) TestActivityHeartbeat() {
 
 func (s *activityTestSuite) TestActivityHeartbeat_InternalError() {
 	ctx, cancel := context.WithCancel(context.Background())
-	invoker := newServiceInvoker([]byte("task-token"), "identity", rpc.NewWorkflowServiceErrorWrapper(s.service), cancel, 1, make(chan struct{}))
+	invoker := newServiceInvoker([]byte("task-token"), "identity", s.service, cancel, 1, make(chan struct{}))
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		serviceInvoker: invoker,
 		logger:         getLogger()})
 
 	s.service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, status.Error(codes.Internal, "")).
+		Return(nil, serviceerror.NewInternal("")).
 		Do(func(ctx context.Context, request *workflowservice.RecordActivityTaskHeartbeatRequest, opts ...grpc.CallOption) {
 			fmt.Println("MOCK RecordActivityTaskHeartbeat executed")
 		}).AnyTimes()
@@ -87,7 +84,7 @@ func (s *activityTestSuite) TestActivityHeartbeat_InternalError() {
 
 func (s *activityTestSuite) TestActivityHeartbeat_CancelRequested() {
 	ctx, cancel := context.WithCancel(context.Background())
-	invoker := newServiceInvoker([]byte("task-token"), "identity", rpc.NewWorkflowServiceErrorWrapper(s.service), cancel, 1, make(chan struct{}))
+	invoker := newServiceInvoker([]byte("task-token"), "identity", s.service, cancel, 1, make(chan struct{}))
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		serviceInvoker: invoker,
 		logger:         getLogger()})
@@ -102,13 +99,13 @@ func (s *activityTestSuite) TestActivityHeartbeat_CancelRequested() {
 
 func (s *activityTestSuite) TestActivityHeartbeat_EntityNotExist() {
 	ctx, cancel := context.WithCancel(context.Background())
-	invoker := newServiceInvoker([]byte("task-token"), "identity", rpc.NewWorkflowServiceErrorWrapper(s.service), cancel, 1, make(chan struct{}))
+	invoker := newServiceInvoker([]byte("task-token"), "identity", s.service, cancel, 1, make(chan struct{}))
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		serviceInvoker: invoker,
 		logger:         getLogger()})
 
 	s.service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&workflowservice.RecordActivityTaskHeartbeatResponse{}, status.Error(codes.NotFound, "")).Times(1)
+		Return(&workflowservice.RecordActivityTaskHeartbeatResponse{}, serviceerror.NewNotFound("")).Times(1)
 
 	RecordActivityHeartbeat(ctx, "testDetails")
 	<-ctx.Done()
@@ -117,7 +114,7 @@ func (s *activityTestSuite) TestActivityHeartbeat_EntityNotExist() {
 
 func (s *activityTestSuite) TestActivityHeartbeat_SuppressContinousInvokes() {
 	ctx, cancel := context.WithCancel(context.Background())
-	invoker := newServiceInvoker([]byte("task-token"), "identity", rpc.NewWorkflowServiceErrorWrapper(s.service), cancel, 2, make(chan struct{}))
+	invoker := newServiceInvoker([]byte("task-token"), "identity", s.service, cancel, 2, make(chan struct{}))
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		serviceInvoker: invoker,
 		logger:         getLogger()})
@@ -132,7 +129,7 @@ func (s *activityTestSuite) TestActivityHeartbeat_SuppressContinousInvokes() {
 
 	// No HB timeout configured.
 	service2 := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
-	invoker2 := newServiceInvoker([]byte("task-token"), "identity", rpc.NewWorkflowServiceErrorWrapper(service2), cancel, 0, make(chan struct{}))
+	invoker2 := newServiceInvoker([]byte("task-token"), "identity", service2, cancel, 0, make(chan struct{}))
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		serviceInvoker: invoker2,
 		logger:         getLogger()})
@@ -145,7 +142,7 @@ func (s *activityTestSuite) TestActivityHeartbeat_SuppressContinousInvokes() {
 	// simulate batch picks before expiry.
 	waitCh := make(chan struct{})
 	service3 := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
-	invoker3 := newServiceInvoker([]byte("task-token"), "identity", rpc.NewWorkflowServiceErrorWrapper(service3), cancel, 2, make(chan struct{}))
+	invoker3 := newServiceInvoker([]byte("task-token"), "identity", service3, cancel, 2, make(chan struct{}))
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		serviceInvoker: invoker3,
 		logger:         getLogger()})
@@ -175,7 +172,7 @@ func (s *activityTestSuite) TestActivityHeartbeat_SuppressContinousInvokes() {
 	// simulate batch picks before expiry, with out any progress specified.
 	waitCh2 := make(chan struct{})
 	service4 := workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
-	invoker4 := newServiceInvoker([]byte("task-token"), "identity", rpc.NewWorkflowServiceErrorWrapper(service4), cancel, 2, make(chan struct{}))
+	invoker4 := newServiceInvoker([]byte("task-token"), "identity", service4, cancel, 2, make(chan struct{}))
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{
 		serviceInvoker: invoker4,
 		logger:         getLogger()})
@@ -199,7 +196,7 @@ func (s *activityTestSuite) TestActivityHeartbeat_SuppressContinousInvokes() {
 func (s *activityTestSuite) TestActivityHeartbeat_WorkerStop() {
 	ctx, cancel := context.WithCancel(context.Background())
 	workerStopChannel := make(chan struct{})
-	invoker := newServiceInvoker([]byte("task-token"), "identity", rpc.NewWorkflowServiceErrorWrapper(s.service), cancel, 5, workerStopChannel)
+	invoker := newServiceInvoker([]byte("task-token"), "identity", s.service, cancel, 5, workerStopChannel)
 	ctx = context.WithValue(ctx, activityEnvContextKey, &activityEnvironment{serviceInvoker: invoker})
 
 	heartBeatDetail := "testDetails"

--- a/internal/client.go
+++ b/internal/client.go
@@ -33,6 +33,7 @@ import (
 	"go.temporal.io/temporal-proto/workflowservice"
 
 	"go.temporal.io/temporal/internal/common/metrics"
+	"go.temporal.io/temporal/internal/common/rpc"
 )
 
 const (
@@ -514,7 +515,7 @@ func NewClient(service workflowservice.WorkflowServiceClient, domain string, opt
 		tracer = opentracing.NoopTracer{}
 	}
 	return &workflowClient{
-		workflowService:    metrics.NewWorkflowServiceWrapper(service, metricScope),
+		workflowService:    metrics.NewWorkflowServiceWrapper(rpc.NewWorkflowServiceErrorWrapper(service), metricScope),
 		domain:             domain,
 		registry:           newRegistry(getGlobalRegistry()),
 		metricsScope:       metrics.NewTaggedScope(metricScope),
@@ -539,7 +540,7 @@ func NewDomainClient(service workflowservice.WorkflowServiceClient, options *Cli
 	}
 	metricScope = tagScope(metricScope, tagDomain, "domain-client", clientImplHeaderName, clientImplHeaderValue)
 	return &domainClient{
-		workflowService: metrics.NewWorkflowServiceWrapper(service, metricScope),
+		workflowService: metrics.NewWorkflowServiceWrapper(rpc.NewWorkflowServiceErrorWrapper(service), metricScope),
 		metricsScope:    metricScope,
 		identity:        identity,
 	}

--- a/internal/common/metrics/service_wrapper_test.go
+++ b/internal/common/metrics/service_wrapper_test.go
@@ -29,15 +29,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/status"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-
+	"go.temporal.io/temporal-proto/serviceerror"
 	"go.temporal.io/temporal-proto/workflowservice"
 	"go.temporal.io/temporal-proto/workflowservicemock"
+	"google.golang.org/grpc"
 )
 
 var (
@@ -94,11 +92,11 @@ func Test_Wrapper(t *testing.T) {
 		{"ResetWorkflowExecution", []interface{}{ctx, &workflowservice.ResetWorkflowExecutionRequest{}}, []interface{}{&workflowservice.ResetWorkflowExecutionResponse{}, nil}, []string{CadenceRequest}},
 		{"UpdateDomain", []interface{}{ctx, &workflowservice.UpdateDomainRequest{}}, []interface{}{&workflowservice.UpdateDomainResponse{}, nil}, []string{CadenceRequest}},
 		// one case of invalid request
-		{"PollForActivityTask", []interface{}{ctx, &workflowservice.PollForActivityTaskRequest{}}, []interface{}{nil, status.New(codes.NotFound, "").Err()}, []string{CadenceRequest, CadenceInvalidRequest}},
+		{"PollForActivityTask", []interface{}{ctx, &workflowservice.PollForActivityTaskRequest{}}, []interface{}{nil, serviceerror.NewNotFound("")}, []string{CadenceRequest, CadenceInvalidRequest}},
 		// one case of server error
-		{"PollForActivityTask", []interface{}{ctx, &workflowservice.PollForActivityTaskRequest{}}, []interface{}{nil, status.New(codes.Internal, "").Err()}, []string{CadenceRequest, CadenceError}},
-		{"QueryWorkflow", []interface{}{ctx, &workflowservice.QueryWorkflowRequest{}}, []interface{}{nil, status.New(codes.Internal, "").Err()}, []string{CadenceRequest, CadenceError}},
-		{"RespondQueryTaskCompleted", []interface{}{ctx, &workflowservice.RespondQueryTaskCompletedRequest{}}, []interface{}{nil, status.New(codes.Internal, "").Err()}, []string{CadenceRequest, CadenceError}},
+		{"PollForActivityTask", []interface{}{ctx, &workflowservice.PollForActivityTaskRequest{}}, []interface{}{nil, serviceerror.NewInternal("")}, []string{CadenceRequest, CadenceError}},
+		{"QueryWorkflow", []interface{}{ctx, &workflowservice.QueryWorkflowRequest{}}, []interface{}{nil, serviceerror.NewInternal("")}, []string{CadenceRequest, CadenceError}},
+		{"RespondQueryTaskCompleted", []interface{}{ctx, &workflowservice.RespondQueryTaskCompletedRequest{}}, []interface{}{nil, serviceerror.NewInternal("")}, []string{CadenceRequest, CadenceError}},
 	}
 
 	// run each test twice - once with the regular scope, once with a sanitized metrics scope

--- a/internal/common/rpc/error_wrapper.go
+++ b/internal/common/rpc/error_wrapper.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rpc
+
+import (
+	"context"
+
+	"github.com/gogo/status"
+	"go.temporal.io/temporal-proto/serviceerror"
+	"go.temporal.io/temporal-proto/workflowservice"
+	"google.golang.org/grpc"
+)
+
+type (
+	workflowServiceErrorWrapper struct {
+		service workflowservice.WorkflowServiceClient
+	}
+)
+
+var (
+	_ workflowservice.WorkflowServiceClient = (*workflowServiceErrorWrapper)(nil)
+)
+
+// NewWorkflowServiceErrorWrapper creates a new wrapper to WorkflowService that will convert gRPC status errors to service errors.
+func NewWorkflowServiceErrorWrapper(service workflowservice.WorkflowServiceClient) *workflowServiceErrorWrapper {
+	return &workflowServiceErrorWrapper{service: service}
+}
+
+func (w *workflowServiceErrorWrapper) convertError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// err is an error from RPC call. It has status.Status from gRPC package (google.golang.org/grpc/status/status.go).
+	// status.Convert converts this error to gogo status.Status.
+	// serviceerror.FromStatus converts gogo Status to serviceerror.
+	return serviceerror.FromStatus(status.Convert(err))
+}
+
+func (w *workflowServiceErrorWrapper) DeprecateDomain(ctx context.Context, request *workflowservice.DeprecateDomainRequest, opts ...grpc.CallOption) (*workflowservice.DeprecateDomainResponse, error) {
+	result, err := w.service.DeprecateDomain(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) ListDomains(ctx context.Context, request *workflowservice.ListDomainsRequest, opts ...grpc.CallOption) (*workflowservice.ListDomainsResponse, error) {
+	result, err := w.service.ListDomains(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) DescribeDomain(ctx context.Context, request *workflowservice.DescribeDomainRequest, opts ...grpc.CallOption) (*workflowservice.DescribeDomainResponse, error) {
+	result, err := w.service.DescribeDomain(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) DescribeWorkflowExecution(ctx context.Context, request *workflowservice.DescribeWorkflowExecutionRequest, opts ...grpc.CallOption) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+	result, err := w.service.DescribeWorkflowExecution(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) GetWorkflowExecutionHistory(ctx context.Context, request *workflowservice.GetWorkflowExecutionHistoryRequest, opts ...grpc.CallOption) (*workflowservice.GetWorkflowExecutionHistoryResponse, error) {
+	result, err := w.service.GetWorkflowExecutionHistory(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) ListClosedWorkflowExecutions(ctx context.Context, request *workflowservice.ListClosedWorkflowExecutionsRequest, opts ...grpc.CallOption) (*workflowservice.ListClosedWorkflowExecutionsResponse, error) {
+	result, err := w.service.ListClosedWorkflowExecutions(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) ListOpenWorkflowExecutions(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest, opts ...grpc.CallOption) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+	result, err := w.service.ListOpenWorkflowExecutions(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) ListWorkflowExecutions(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest, opts ...grpc.CallOption) (*workflowservice.ListWorkflowExecutionsResponse, error) {
+	result, err := w.service.ListWorkflowExecutions(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) ListArchivedWorkflowExecutions(ctx context.Context, request *workflowservice.ListArchivedWorkflowExecutionsRequest, opts ...grpc.CallOption) (*workflowservice.ListArchivedWorkflowExecutionsResponse, error) {
+	result, err := w.service.ListArchivedWorkflowExecutions(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) ScanWorkflowExecutions(ctx context.Context, request *workflowservice.ScanWorkflowExecutionsRequest, opts ...grpc.CallOption) (*workflowservice.ScanWorkflowExecutionsResponse, error) {
+	result, err := w.service.ScanWorkflowExecutions(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) CountWorkflowExecutions(ctx context.Context, request *workflowservice.CountWorkflowExecutionsRequest, opts ...grpc.CallOption) (*workflowservice.CountWorkflowExecutionsResponse, error) {
+	result, err := w.service.CountWorkflowExecutions(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) PollForActivityTask(ctx context.Context, request *workflowservice.PollForActivityTaskRequest, opts ...grpc.CallOption) (*workflowservice.PollForActivityTaskResponse, error) {
+	result, err := w.service.PollForActivityTask(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) PollForDecisionTask(ctx context.Context, request *workflowservice.PollForDecisionTaskRequest, opts ...grpc.CallOption) (*workflowservice.PollForDecisionTaskResponse, error) {
+	result, err := w.service.PollForDecisionTask(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RecordActivityTaskHeartbeat(ctx context.Context, request *workflowservice.RecordActivityTaskHeartbeatRequest, opts ...grpc.CallOption) (*workflowservice.RecordActivityTaskHeartbeatResponse, error) {
+	result, err := w.service.RecordActivityTaskHeartbeat(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RecordActivityTaskHeartbeatByID(ctx context.Context, request *workflowservice.RecordActivityTaskHeartbeatByIDRequest, opts ...grpc.CallOption) (*workflowservice.RecordActivityTaskHeartbeatByIDResponse, error) {
+	result, err := w.service.RecordActivityTaskHeartbeatByID(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RegisterDomain(ctx context.Context, request *workflowservice.RegisterDomainRequest, opts ...grpc.CallOption) (*workflowservice.RegisterDomainResponse, error) {
+	result, err := w.service.RegisterDomain(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RequestCancelWorkflowExecution(ctx context.Context, request *workflowservice.RequestCancelWorkflowExecutionRequest, opts ...grpc.CallOption) (*workflowservice.RequestCancelWorkflowExecutionResponse, error) {
+	result, err := w.service.RequestCancelWorkflowExecution(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RespondActivityTaskCanceled(ctx context.Context, request *workflowservice.RespondActivityTaskCanceledRequest, opts ...grpc.CallOption) (*workflowservice.RespondActivityTaskCanceledResponse, error) {
+	result, err := w.service.RespondActivityTaskCanceled(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RespondActivityTaskCompleted(ctx context.Context, request *workflowservice.RespondActivityTaskCompletedRequest, opts ...grpc.CallOption) (*workflowservice.RespondActivityTaskCompletedResponse, error) {
+	result, err := w.service.RespondActivityTaskCompleted(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RespondActivityTaskFailed(ctx context.Context, request *workflowservice.RespondActivityTaskFailedRequest, opts ...grpc.CallOption) (*workflowservice.RespondActivityTaskFailedResponse, error) {
+	result, err := w.service.RespondActivityTaskFailed(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RespondActivityTaskCanceledByID(ctx context.Context, request *workflowservice.RespondActivityTaskCanceledByIDRequest, opts ...grpc.CallOption) (*workflowservice.RespondActivityTaskCanceledByIDResponse, error) {
+	result, err := w.service.RespondActivityTaskCanceledByID(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RespondActivityTaskCompletedByID(ctx context.Context, request *workflowservice.RespondActivityTaskCompletedByIDRequest, opts ...grpc.CallOption) (*workflowservice.RespondActivityTaskCompletedByIDResponse, error) {
+	result, err := w.service.RespondActivityTaskCompletedByID(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RespondActivityTaskFailedByID(ctx context.Context, request *workflowservice.RespondActivityTaskFailedByIDRequest, opts ...grpc.CallOption) (*workflowservice.RespondActivityTaskFailedByIDResponse, error) {
+	result, err := w.service.RespondActivityTaskFailedByID(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RespondDecisionTaskCompleted(ctx context.Context, request *workflowservice.RespondDecisionTaskCompletedRequest, opts ...grpc.CallOption) (*workflowservice.RespondDecisionTaskCompletedResponse, error) {
+	result, err := w.service.RespondDecisionTaskCompleted(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RespondDecisionTaskFailed(ctx context.Context, request *workflowservice.RespondDecisionTaskFailedRequest, opts ...grpc.CallOption) (*workflowservice.RespondDecisionTaskFailedResponse, error) {
+	result, err := w.service.RespondDecisionTaskFailed(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) SignalWorkflowExecution(ctx context.Context, request *workflowservice.SignalWorkflowExecutionRequest, opts ...grpc.CallOption) (*workflowservice.SignalWorkflowExecutionResponse, error) {
+	result, err := w.service.SignalWorkflowExecution(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) SignalWithStartWorkflowExecution(ctx context.Context, request *workflowservice.SignalWithStartWorkflowExecutionRequest, opts ...grpc.CallOption) (*workflowservice.SignalWithStartWorkflowExecutionResponse, error) {
+	result, err := w.service.SignalWithStartWorkflowExecution(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) StartWorkflowExecution(ctx context.Context, request *workflowservice.StartWorkflowExecutionRequest, opts ...grpc.CallOption) (*workflowservice.StartWorkflowExecutionResponse, error) {
+	result, err := w.service.StartWorkflowExecution(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) TerminateWorkflowExecution(ctx context.Context, request *workflowservice.TerminateWorkflowExecutionRequest, opts ...grpc.CallOption) (*workflowservice.TerminateWorkflowExecutionResponse, error) {
+	result, err := w.service.TerminateWorkflowExecution(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) ResetWorkflowExecution(ctx context.Context, request *workflowservice.ResetWorkflowExecutionRequest, opts ...grpc.CallOption) (*workflowservice.ResetWorkflowExecutionResponse, error) {
+	result, err := w.service.ResetWorkflowExecution(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) UpdateDomain(ctx context.Context, request *workflowservice.UpdateDomainRequest, opts ...grpc.CallOption) (*workflowservice.UpdateDomainResponse, error) {
+	result, err := w.service.UpdateDomain(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) QueryWorkflow(ctx context.Context, request *workflowservice.QueryWorkflowRequest, opts ...grpc.CallOption) (*workflowservice.QueryWorkflowResponse, error) {
+	result, err := w.service.QueryWorkflow(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) ResetStickyTaskList(ctx context.Context, request *workflowservice.ResetStickyTaskListRequest, opts ...grpc.CallOption) (*workflowservice.ResetStickyTaskListResponse, error) {
+	result, err := w.service.ResetStickyTaskList(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) DescribeTaskList(ctx context.Context, request *workflowservice.DescribeTaskListRequest, opts ...grpc.CallOption) (*workflowservice.DescribeTaskListResponse, error) {
+	result, err := w.service.DescribeTaskList(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) RespondQueryTaskCompleted(ctx context.Context, request *workflowservice.RespondQueryTaskCompletedRequest, opts ...grpc.CallOption) (*workflowservice.RespondQueryTaskCompletedResponse, error) {
+	result, err := w.service.RespondQueryTaskCompleted(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) GetSearchAttributes(ctx context.Context, request *workflowservice.GetSearchAttributesRequest, opts ...grpc.CallOption) (*workflowservice.GetSearchAttributesResponse, error) {
+	result, err := w.service.GetSearchAttributes(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) GetClusterInfo(ctx context.Context, request *workflowservice.GetClusterInfoRequest, opts ...grpc.CallOption) (*workflowservice.GetClusterInfoResponse, error) {
+	result, err := w.service.GetClusterInfo(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) ListTaskListPartitions(ctx context.Context, request *workflowservice.ListTaskListPartitionsRequest, opts ...grpc.CallOption) (*workflowservice.ListTaskListPartitionsResponse, error) {
+	result, err := w.service.ListTaskListPartitions(ctx, request, opts...)
+	return result, w.convertError(err)
+}
+
+func (w *workflowServiceErrorWrapper) GetWorkflowExecutionRawHistory(ctx context.Context, request *workflowservice.GetWorkflowExecutionRawHistoryRequest, opts ...grpc.CallOption) (*workflowservice.GetWorkflowExecutionRawHistoryResponse, error) {
+	result, err := w.service.GetWorkflowExecutionRawHistory(ctx, request, opts...)
+	return result, w.convertError(err)
+}

--- a/internal/common/rpc/error_wrapper_test.go
+++ b/internal/common/rpc/error_wrapper_test.go
@@ -1,0 +1,41 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/gogo/status"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/temporal-proto/errordetails"
+	"go.temporal.io/temporal-proto/serviceerror"
+	"go.temporal.io/temporal-proto/workflowservicemock"
+	"google.golang.org/grpc/codes"
+)
+
+func TestErrorWrapper_NotFound(t *testing.T) {
+	require := require.New(t)
+	wrapper := NewWorkflowServiceErrorWrapper(workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t)))
+
+	st := status.Error(codes.NotFound, "Something not found")
+
+	svcerr := wrapper.convertError(st)
+	require.IsType(&serviceerror.NotFound{}, svcerr)
+	require.Equal("Something not found", svcerr.Error())
+}
+
+func TestErrorWrapper_WorkflowExecutionAlreadyStarted(t *testing.T) {
+	require := require.New(t)
+	wrapper := NewWorkflowServiceErrorWrapper(workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t)))
+
+	st, _ := status.New(codes.AlreadyExists, "Something started").WithDetails(&errordetails.WorkflowExecutionAlreadyStartedFailure{
+		StartRequestId: "srId",
+		RunId:          "rId",
+	})
+
+	svcerr := wrapper.convertError(st.Err())
+	require.IsType(&serviceerror.WorkflowExecutionAlreadyStarted{}, svcerr)
+	require.Equal("Something started", svcerr.Error())
+	weasErr := svcerr.(*serviceerror.WorkflowExecutionAlreadyStarted)
+	require.Equal("rId", weasErr.RunId)
+	require.Equal("srId", weasErr.StartRequestId)
+}

--- a/internal/common/rpc/error_wrapper_test.go
+++ b/internal/common/rpc/error_wrapper_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-func TestErrorWrapper_NotFound(t *testing.T) {
+func TestErrorWrapper_SimpleError(t *testing.T) {
 	require := require.New(t)
 	wrapper := NewWorkflowServiceErrorWrapper(workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t)))
 
@@ -23,7 +23,7 @@ func TestErrorWrapper_NotFound(t *testing.T) {
 	require.Equal("Something not found", svcerr.Error())
 }
 
-func TestErrorWrapper_WorkflowExecutionAlreadyStarted(t *testing.T) {
+func TestErrorWrapper_ErrorWithFailure(t *testing.T) {
 	require := require.New(t)
 	wrapper := NewWorkflowServiceErrorWrapper(workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t)))
 

--- a/internal/internal_event_handlers.go
+++ b/internal/internal_event_handlers.go
@@ -34,7 +34,7 @@ import (
 	"github.com/uber-go/tally"
 	commonproto "go.temporal.io/temporal-proto/common"
 	"go.temporal.io/temporal-proto/enums"
-	"go.temporal.io/temporal-proto/errordetails"
+	"go.temporal.io/temporal-proto/serviceerror"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -1157,8 +1157,8 @@ func (weh *workflowExecutionEventHandlerImpl) handleStartChildWorkflowExecutionF
 		return nil
 	}
 
-	st := errordetails.NewWorkflowExecutionAlreadyStartedStatus("Workflow execution already started", "", "")
-	childWorkflow.handle(nil, st.Err())
+	err := serviceerror.NewWorkflowExecutionAlreadyStarted("Workflow execution already started", "", "")
+	childWorkflow.handle(nil, err)
 
 	return nil
 }

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -37,18 +37,17 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gogo/status"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pborman/uuid"
 	"github.com/uber-go/tally"
+	"go.temporal.io/temporal-proto/serviceerror"
+	"go.temporal.io/temporal-proto/workflowservice"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"google.golang.org/grpc/codes"
-
-	"go.temporal.io/temporal-proto/workflowservice"
 
 	"go.temporal.io/temporal/internal/common/backoff"
 	"go.temporal.io/temporal/internal/common/metrics"
+	"go.temporal.io/temporal/internal/common/rpc"
 )
 
 const (
@@ -232,11 +231,11 @@ func verifyDomainExist(client workflowservice.WorkflowServiceClient, domain stri
 		defer cancel()
 		_, err := client.DescribeDomain(tchCtx, &workflowservice.DescribeDomainRequest{Name: domain})
 		if err != nil {
-			switch status.Code(err) {
-			case codes.NotFound:
+			switch err.(type) {
+			case *serviceerror.NotFound:
 				logger.Error("domain does not exist", zap.String("domain", domain), zap.Error(err))
 				return err
-			case codes.InvalidArgument:
+			case *serviceerror.InvalidArgument:
 				logger.Error("domain does not exist", zap.String("domain", domain), zap.Error(err))
 				return err
 			}
@@ -1222,7 +1221,7 @@ func newAggregatedWorker(
 		zapcore.Field{Key: tagWorkerID, Type: zapcore.StringType, String: workerParams.Identity},
 	)
 	logger := workerParams.Logger
-	service = metrics.NewWorkflowServiceWrapper(service, workerParams.MetricsScope)
+	service = metrics.NewWorkflowServiceWrapper(rpc.NewWorkflowServiceErrorWrapper(service), workerParams.MetricsScope)
 
 	processTestTags(&wOptions, &workerParams)
 

--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -35,8 +35,6 @@ import (
 	"go.temporal.io/temporal-proto/enums"
 	"go.temporal.io/temporal-proto/workflowservice"
 	"go.temporal.io/temporal-proto/workflowservicemock"
-
-	"go.temporal.io/temporal/internal/common/rpc"
 )
 
 const (
@@ -203,7 +201,7 @@ func (s *InterfacesTestSuite) TestInterface() {
 
 	registry := getGlobalRegistry()
 	// Launch worker.
-	workflowWorker := newWorkflowWorker(rpc.NewWorkflowServiceErrorWrapper(s.service), domain, workflowExecutionParameters, nil, registry)
+	workflowWorker := newWorkflowWorker(s.service, domain, workflowExecutionParameters, nil, registry)
 	defer workflowWorker.Stop()
 	_ = workflowWorker.Start()
 
@@ -216,7 +214,7 @@ func (s *InterfacesTestSuite) TestInterface() {
 	}
 
 	// Register activity instances and launch the worker.
-	activityWorker := newActivityWorker(rpc.NewWorkflowServiceErrorWrapper(s.service), domain, activityExecutionParameters, nil, registry, nil)
+	activityWorker := newActivityWorker(s.service, domain, activityExecutionParameters, nil, registry, nil)
 	defer activityWorker.Stop()
 	_ = activityWorker.Start()
 

--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -35,6 +35,8 @@ import (
 	"go.temporal.io/temporal-proto/enums"
 	"go.temporal.io/temporal-proto/workflowservice"
 	"go.temporal.io/temporal-proto/workflowservicemock"
+
+	"go.temporal.io/temporal/internal/common/rpc"
 )
 
 const (
@@ -201,7 +203,7 @@ func (s *InterfacesTestSuite) TestInterface() {
 
 	registry := getGlobalRegistry()
 	// Launch worker.
-	workflowWorker := newWorkflowWorker(s.service, domain, workflowExecutionParameters, nil, registry)
+	workflowWorker := newWorkflowWorker(rpc.NewWorkflowServiceErrorWrapper(s.service), domain, workflowExecutionParameters, nil, registry)
 	defer workflowWorker.Stop()
 	_ = workflowWorker.Start()
 
@@ -214,7 +216,7 @@ func (s *InterfacesTestSuite) TestInterface() {
 	}
 
 	// Register activity instances and launch the worker.
-	activityWorker := newActivityWorker(s.service, domain, activityExecutionParameters, nil, registry, nil)
+	activityWorker := newActivityWorker(rpc.NewWorkflowServiceErrorWrapper(s.service), domain, activityExecutionParameters, nil, registry, nil)
 	defer activityWorker.Stop()
 	_ = activityWorker.Start()
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -35,14 +35,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-
 	commonproto "go.temporal.io/temporal-proto/common"
 	"go.temporal.io/temporal-proto/enums"
 	"go.temporal.io/temporal-proto/workflowservice"
 	"go.temporal.io/temporal-proto/workflowservicemock"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 func init() {
@@ -437,9 +436,9 @@ func (s *internalWorkerTestSuite) TestWorkerStartFailsWithInvalidDomain() {
 		domainErr  error
 		isErrFatal bool
 	}{
-		{status.New(codes.NotFound, "").Err(), true},
-		{status.New(codes.InvalidArgument, "").Err(), true},
-		{status.New(codes.Internal, "").Err(), false},
+		{status.Error(codes.NotFound, ""), true},
+		{status.Error(codes.InvalidArgument, ""), true},
+		{status.Error(codes.Internal, ""), false},
 		{errors.New("unknown"), false},
 	}
 

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -41,7 +41,6 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"go.temporal.io/temporal/internal/common/metrics"
-	"go.temporal.io/temporal/internal/common/rpc"
 )
 
 const (
@@ -150,7 +149,7 @@ func (s *historyEventIteratorSuite) SetupTest() {
 	s.workflowServiceClient = workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
 
 	s.wfClient = &workflowClient{
-		workflowService: rpc.NewWorkflowServiceErrorWrapper(s.workflowServiceClient),
+		workflowService: s.workflowServiceClient,
 		domain:          domain,
 	}
 }
@@ -254,7 +253,7 @@ func (s *historyEventIteratorSuite) TestIterator_Error() {
 	s.NotNil(event)
 	s.Nil(err)
 
-	s.workflowServiceClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), request2, gomock.Any()).Return(nil, status.Error(codes.NotFound, "")).Times(1)
+	s.workflowServiceClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), request2, gomock.Any()).Return(nil, serviceerror.NewNotFound("")).Times(1)
 
 	s.True(iter.HasNext())
 	event, err = iter.Next()

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -30,19 +30,18 @@ import (
 	"time"
 
 	"github.com/gogo/status"
-	"google.golang.org/grpc/codes"
-
 	"github.com/golang/mock/gomock"
-	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/suite"
-
 	commonproto "go.temporal.io/temporal-proto/common"
 	"go.temporal.io/temporal-proto/enums"
 	"go.temporal.io/temporal-proto/errordetails"
+	"go.temporal.io/temporal-proto/serviceerror"
 	"go.temporal.io/temporal-proto/workflowservice"
 	"go.temporal.io/temporal-proto/workflowservicemock"
+	"google.golang.org/grpc/codes"
 
 	"go.temporal.io/temporal/internal/common/metrics"
+	"go.temporal.io/temporal/internal/common/rpc"
 )
 
 const (
@@ -151,7 +150,7 @@ func (s *historyEventIteratorSuite) SetupTest() {
 	s.workflowServiceClient = workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
 
 	s.wfClient = &workflowClient{
-		workflowService: s.workflowServiceClient,
+		workflowService: rpc.NewWorkflowServiceErrorWrapper(s.workflowServiceClient),
 		domain:          domain,
 	}
 }
@@ -255,7 +254,7 @@ func (s *historyEventIteratorSuite) TestIterator_Error() {
 	s.NotNil(event)
 	s.Nil(err)
 
-	s.workflowServiceClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), request2, gomock.Any()).Return(nil, status.New(codes.NotFound, "").Err()).Times(1)
+	s.workflowServiceClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), request2, gomock.Any()).Return(nil, status.Error(codes.NotFound, "")).Times(1)
 
 	s.True(iter.HasNext())
 	event, err = iter.Next()
@@ -352,11 +351,12 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Success() {
 }
 
 func (s *workflowRunSuite) TestExecuteWorkflowWorkflowExecutionAlreadyStartedError() {
-	st := errordetails.NewWorkflowExecutionAlreadyStartedStatus("Already Started", uuid.NewRandom().String(), runID)
-	alreadyStartedErr := st.Err()
+	st, err := status.New(codes.AlreadyExists, "Already Started").
+		WithDetails(&errordetails.WorkflowExecutionAlreadyStartedFailure{RunId: runID})
+	s.NoError(err)
 
 	s.workflowServiceClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, alreadyStartedErr).Times(1)
+		Return(nil, st.Err()).Times(1)
 
 	eventType := enums.EventTypeWorkflowExecutionCompleted
 	workflowResult := time.Hour * 59
@@ -1049,14 +1049,13 @@ func (s *workflowClientTestSuite) TestListWorkflow() {
 	s.Nil(err)
 	s.Equal(response, resp)
 
-	responseErr := status.New(codes.InvalidArgument, "").Err()
 	request.Domain = "another"
-	s.service.EXPECT().ListWorkflowExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, responseErr).
+	s.service.EXPECT().ListWorkflowExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, status.Error(codes.InvalidArgument, "")).
 		Do(func(_ interface{}, req *workflowservice.ListWorkflowExecutionsRequest, _ ...interface{}) {
 			s.Equal("another", request.GetDomain())
 		})
 	_, err = s.client.ListWorkflow(context.Background(), request)
-	s.Equal(responseErr, err)
+	s.IsType(&serviceerror.InvalidArgument{}, err)
 }
 
 func (s *workflowClientTestSuite) TestListArchivedWorkflow() {
@@ -1072,14 +1071,13 @@ func (s *workflowClientTestSuite) TestListArchivedWorkflow() {
 	s.Nil(err)
 	s.Equal(response, resp)
 
-	responseErr := status.New(codes.InvalidArgument, "").Err()
 	request.Domain = "another"
-	s.service.EXPECT().ListArchivedWorkflowExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, responseErr).
+	s.service.EXPECT().ListArchivedWorkflowExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, status.Error(codes.InvalidArgument, "")).
 		Do(func(_ interface{}, req *workflowservice.ListArchivedWorkflowExecutionsRequest, _ ...interface{}) {
 			s.Equal("another", request.GetDomain())
 		})
 	_, err = s.client.ListArchivedWorkflow(ctxWithTimeout, request)
-	s.Equal(responseErr, err)
+	s.IsType(&serviceerror.InvalidArgument{}, err)
 }
 
 func (s *workflowClientTestSuite) TestScanWorkflow() {
@@ -1093,14 +1091,13 @@ func (s *workflowClientTestSuite) TestScanWorkflow() {
 	s.Nil(err)
 	s.Equal(response, resp)
 
-	responseErr := status.New(codes.InvalidArgument, "").Err()
 	request.Domain = "another"
-	s.service.EXPECT().ScanWorkflowExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, responseErr).
+	s.service.EXPECT().ScanWorkflowExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, status.Error(codes.InvalidArgument, "")).
 		Do(func(_ interface{}, req *workflowservice.ScanWorkflowExecutionsRequest, _ ...interface{}) {
 			s.Equal("another", request.GetDomain())
 		})
 	_, err = s.client.ScanWorkflow(context.Background(), request)
-	s.Equal(responseErr, err)
+	s.IsType(&serviceerror.InvalidArgument{}, err)
 }
 
 func (s *workflowClientTestSuite) TestCountWorkflow() {
@@ -1114,14 +1111,13 @@ func (s *workflowClientTestSuite) TestCountWorkflow() {
 	s.Nil(err)
 	s.Equal(response, resp)
 
-	responseErr := status.New(codes.InvalidArgument, "").Err()
 	request.Domain = "another"
-	s.service.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, responseErr).
+	s.service.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, status.Error(codes.InvalidArgument, "")).
 		Do(func(_ interface{}, req *workflowservice.CountWorkflowExecutionsRequest, _ ...interface{}) {
 			s.Equal("another", request.GetDomain())
 		})
 	_, err = s.client.CountWorkflow(context.Background(), request)
-	s.Equal(responseErr, err)
+	s.IsType(&serviceerror.InvalidArgument{}, err)
 }
 
 func (s *workflowClientTestSuite) TestGetSearchAttributes() {
@@ -1131,8 +1127,7 @@ func (s *workflowClientTestSuite) TestGetSearchAttributes() {
 	s.Nil(err)
 	s.Equal(response, resp)
 
-	responseErr := status.New(codes.InvalidArgument, "").Err()
-	s.service.EXPECT().GetSearchAttributes(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, responseErr)
+	s.service.EXPECT().GetSearchAttributes(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, status.Error(codes.InvalidArgument, ""))
 	_, err = s.client.GetSearchAttributes(context.Background())
-	s.Equal(responseErr, err)
+	s.IsType(&serviceerror.InvalidArgument{}, err)
 }

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -36,18 +36,18 @@ import (
 	"github.com/robfig/cron"
 	"github.com/stretchr/testify/mock"
 	"github.com/uber-go/tally"
+	commonproto "go.temporal.io/temporal-proto/common"
+	"go.temporal.io/temporal-proto/enums"
+	"go.temporal.io/temporal-proto/serviceerror"
+	"go.temporal.io/temporal-proto/workflowservice"
+	"go.temporal.io/temporal-proto/workflowservicemock"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	commonproto "go.temporal.io/temporal-proto/common"
-	"go.temporal.io/temporal-proto/enums"
-	"go.temporal.io/temporal-proto/errordetails"
-	"go.temporal.io/temporal-proto/workflowservice"
-	"go.temporal.io/temporal-proto/workflowservicemock"
-
 	"go.temporal.io/temporal/internal/common"
 	"go.temporal.io/temporal/internal/common/metrics"
+	"go.temporal.io/temporal/internal/common/rpc"
 )
 
 const (
@@ -263,7 +263,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite) *testWorkflowEnvironme
 		if !ok {
 			env.logger.Debug("RecordActivityTaskHeartbeat: ActivityID not found, could be already completed or cancelled.",
 				zap.String(tagActivityID, activityID))
-			return status.New(codes.NotFound, "").Err()
+			return status.Error(codes.NotFound, "")
 		}
 		activityHandle.heartbeatDetails = r.Details
 		activityInfo := env.getActivityInfo(activityID, activityHandle.activityType)
@@ -348,16 +348,13 @@ func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(param
 	if workflowHandler, ok := env.runningWorkflows[params.workflowID]; ok {
 		// duplicate workflow ID
 		if !workflowHandler.handled {
-			st := errordetails.NewWorkflowExecutionAlreadyStartedStatus("Workflow execution already started", "", "")
-			return nil, st.Err()
+			return nil, serviceerror.NewWorkflowExecutionAlreadyStarted("Workflow execution already started", "", "")
 		}
 		if params.workflowIDReusePolicy == WorkflowIDReusePolicyRejectDuplicate {
-			st := errordetails.NewWorkflowExecutionAlreadyStartedStatus("Workflow execution already started", "", "")
-			return nil, st.Err()
+			return nil, serviceerror.NewWorkflowExecutionAlreadyStarted("Workflow execution already started", "", "")
 		}
 		if workflowHandler.err == nil && params.workflowIDReusePolicy == WorkflowIDReusePolicyAllowDuplicateFailedOnly {
-			st := errordetails.NewWorkflowExecutionAlreadyStartedStatus("Workflow execution already started", "", "")
-			return nil, st.Err()
+			return nil, serviceerror.NewWorkflowExecutionAlreadyStarted("Workflow execution already started", "", "")
 		}
 	}
 
@@ -1536,7 +1533,7 @@ func (env *testWorkflowEnvironmentImpl) newTestActivityTaskHandler(taskList stri
 		return &activityExecutorWrapper{activityExecutor: ae, env: env}
 	}
 
-	taskHandler := newActivityTaskHandlerWithCustomProvider(env.service, params, registry, getActivity)
+	taskHandler := newActivityTaskHandlerWithCustomProvider(rpc.NewWorkflowServiceErrorWrapper(env.service), params, registry, getActivity)
 	return taskHandler
 }
 
@@ -1905,7 +1902,7 @@ func (env *testWorkflowEnvironmentImpl) signalWorkflowByID(workflowID, signalNam
 
 	if workflowHandle, ok := env.runningWorkflows[workflowID]; ok {
 		if workflowHandle.handled {
-			return status.New(codes.NotFound, fmt.Sprintf("Workflow %v already completed", workflowID)).Err()
+			return serviceerror.NewNotFound(fmt.Sprintf("Workflow %v already completed", workflowID))
 		}
 		workflowHandle.env.postCallback(func() {
 			workflowHandle.env.signalHandler(signalName, data)
@@ -1913,7 +1910,7 @@ func (env *testWorkflowEnvironmentImpl) signalWorkflowByID(workflowID, signalNam
 		return nil
 	}
 
-	return status.New(codes.NotFound, fmt.Sprintf("Workflow %v not exists", workflowID)).Err()
+	return serviceerror.NewNotFound(fmt.Sprintf("Workflow %v not exists", workflowID))
 }
 
 func (env *testWorkflowEnvironmentImpl) queryWorkflow(queryType string, args ...interface{}) (Value, error) {

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -47,7 +47,6 @@ import (
 
 	"go.temporal.io/temporal/internal/common"
 	"go.temporal.io/temporal/internal/common/metrics"
-	"go.temporal.io/temporal/internal/common/rpc"
 )
 
 const (
@@ -1533,7 +1532,7 @@ func (env *testWorkflowEnvironmentImpl) newTestActivityTaskHandler(taskList stri
 		return &activityExecutorWrapper{activityExecutor: ae, env: env}
 	}
 
-	taskHandler := newActivityTaskHandlerWithCustomProvider(rpc.NewWorkflowServiceErrorWrapper(env.service), params, registry, getActivity)
+	taskHandler := newActivityTaskHandlerWithCustomProvider(env.service, params, registry, getActivity)
 	return taskHandler
 }
 

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -30,14 +30,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/status"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.temporal.io/temporal-proto/serviceerror"
 	"go.uber.org/zap"
 
 	commonproto "go.temporal.io/temporal-proto/common"
 	"go.temporal.io/temporal-proto/enums"
-	"go.temporal.io/temporal-proto/errordetails"
 )
 
 type WorkflowTestSuiteUnitTest struct {
@@ -2586,7 +2585,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflowAlreadyRunning() {
 
 		err = f2.Get(ctx1, &result2)
 		s.Error(err)
-		s.True(errordetails.IsWorkflowExecutionAlreadyStartedStatus(status.Convert(err)))
+		s.IsType(&serviceerror.WorkflowExecutionAlreadyStarted{}, err)
 
 		return result1 + " " + result2, nil
 	}

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -40,6 +40,8 @@ import (
 	"go.temporal.io/temporal-proto/enums"
 	"go.temporal.io/temporal-proto/workflowservice"
 	"go.temporal.io/temporal-proto/workflowservicemock"
+
+	"go.temporal.io/temporal/internal/common/rpc"
 )
 
 type (
@@ -361,7 +363,7 @@ func replayWorkflowHistory(logger *zap.Logger, service workflowservice.WorkflowS
 		nextPageToken: task.NextPageToken,
 		execution:     task.WorkflowExecution,
 		domain:        ReplayDomainName,
-		service:       service,
+		service:       rpc.NewWorkflowServiceErrorWrapper(service),
 		metricsScope:  metricScope,
 		maxEventID:    task.GetStartedEventId(),
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -28,15 +28,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/status"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/temporal-proto/enums"
+	"go.temporal.io/temporal-proto/serviceerror"
 	"go.temporal.io/temporal-proto/workflowservice"
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
-	"google.golang.org/grpc/codes"
 
 	"go.temporal.io/temporal"
 	"go.temporal.io/temporal/client"
@@ -289,7 +288,7 @@ func (ts *IntegrationTestSuite) TestWorkflowIDReuseRejectDuplicate() {
 	ts.Error(err)
 	gerr, ok := err.(*workflow.GenericError)
 	ts.True(ok)
-	ts.True(strings.HasPrefix(gerr.Error(), "rpc error: code = AlreadyExists"), "Error message is %q and does not have \"rpc error: code = AlreadyExists\" prefix", gerr.Error())
+	ts.Equal("Workflow execution already started", gerr.Error())
 }
 
 func (ts *IntegrationTestSuite) TestWorkflowIDReuseAllowDuplicateFailedOnly1() {
@@ -306,7 +305,7 @@ func (ts *IntegrationTestSuite) TestWorkflowIDReuseAllowDuplicateFailedOnly1() {
 	ts.Error(err)
 	gerr, ok := err.(*workflow.GenericError)
 	ts.True(ok)
-	ts.True(strings.HasPrefix(gerr.Error(), "rpc error: code = AlreadyExists"), "Error message is %q and does not have \"rpc error: code = AlreadyExists\" prefix", gerr.Error())
+	ts.Equal("Workflow execution already started", gerr.Error())
 }
 
 func (ts *IntegrationTestSuite) TestWorkflowIDReuseAllowDuplicateFailedOnly2() {
@@ -403,9 +402,8 @@ func (ts *IntegrationTestSuite) TestLargeQueryResultError() {
 	value, err := ts.libClient.QueryWorkflow(ctx, "test-large-query-error", run.GetRunID(), "large_query")
 	ts.Error(err)
 
-	st := status.Convert(err)
-	ts.Equal(codes.InvalidArgument, st.Code())
-	ts.Equal("query result size (3000000) exceeds limit (2000000)", st.Message())
+	ts.IsType(&serviceerror.InvalidArgument{}, err)
+	ts.Equal("query result size (3000000) exceeds limit (2000000)", err.Error())
 	ts.Nil(value)
 }
 
@@ -420,7 +418,7 @@ func (ts *IntegrationTestSuite) registerDomain() {
 		WorkflowExecutionRetentionPeriodInDays: retention,
 	})
 	if err != nil {
-		if status.Code(err) == codes.AlreadyExists {
+		if _, ok := err.(*serviceerror.DomainAlreadyExists); ok {
 			return
 		}
 	}
@@ -431,7 +429,7 @@ func (ts *IntegrationTestSuite) registerDomain() {
 	err = ts.executeWorkflow("test-domain-exist", ts.workflows.SimplestWorkflow, &dummyReturn)
 	numOfRetry := 20
 	for err != nil && numOfRetry >= 0 {
-		if status.Code(err) == codes.NotFound {
+		if _, ok := err.(*serviceerror.NotFound); ok {
 			time.Sleep(domainCacheRefreshInterval)
 			err = ts.executeWorkflow("test-domain-exist", ts.workflows.SimplestWorkflow, &dummyReturn)
 		} else {


### PR DESCRIPTION
1. Updated to latest `temporal-proto` module.
2. Created `workflowServiceErrorWrapper` which converts gRPC status error to service error.
3. Replaced `status.Status` with `serviceerror` everywhere in the code.