### PR TITLE
Rename errordetails to failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/uber-go/tally v3.3.13+incompatible
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
-	go.temporal.io/temporal-proto v0.0.0-20200220011422-f48cb2702adc
+	go.temporal.io/temporal-proto v0.0.0-20200225194333-1f486e8c9e9c
 	go.uber.org/atomic v1.5.1
 	go.uber.org/goleak v0.10.0
 	go.uber.org/multierr v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/uber/jaeger-client-go v2.22.1+incompatible h1:NHcubEkVbahf9t3p75TOCR8
 github.com/uber/jaeger-client-go v2.22.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
-go.temporal.io/temporal-proto v0.0.0-20200220011422-f48cb2702adc h1:68PyU/2L6jHNXfoXQbi/pTDQ3/HO8O8ReBb6x23grQY=
-go.temporal.io/temporal-proto v0.0.0-20200220011422-f48cb2702adc/go.mod h1:SszgPhzKZvtDenZxaN68OKKj1RD1uVmDOHUn1RnTctk=
+go.temporal.io/temporal-proto v0.0.0-20200225194333-1f486e8c9e9c h1:y0AMRg3saksszcvf2piNBrQs1JP3dSkubD0LAdZmB78=
+go.temporal.io/temporal-proto v0.0.0-20200225194333-1f486e8c9e9c/go.mod h1:SszgPhzKZvtDenZxaN68OKKj1RD1uVmDOHUn1RnTctk=
 go.uber.org/atomic v1.5.0 h1:OI5t8sDa1Or+q8AeE+yKeB/SDYioSHAgcVljj9JIETY=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.5.1 h1:rsqfU5vBkVknbhUGbAUwQKR2H4ItV8tjJ+6kJX4cxHM=

--- a/internal/common/rpc/error_wrapper_test.go
+++ b/internal/common/rpc/error_wrapper_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gogo/status"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-	"go.temporal.io/temporal-proto/errordetails"
+	"go.temporal.io/temporal-proto/failure"
 	"go.temporal.io/temporal-proto/serviceerror"
 	"go.temporal.io/temporal-proto/workflowservicemock"
 	"google.golang.org/grpc/codes"
@@ -27,7 +27,7 @@ func TestErrorWrapper_ErrorWithFailure(t *testing.T) {
 	require := require.New(t)
 	wrapper := NewWorkflowServiceErrorWrapper(workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t)))
 
-	st, _ := status.New(codes.AlreadyExists, "Something started").WithDetails(&errordetails.WorkflowExecutionAlreadyStartedFailure{
+	st, _ := status.New(codes.AlreadyExists, "Something started").WithDetails(&failure.WorkflowExecutionAlreadyStarted{
 		StartRequestId: "srId",
 		RunId:          "rId",
 	})

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	commonproto "go.temporal.io/temporal-proto/common"
 	"go.temporal.io/temporal-proto/enums"
-	"go.temporal.io/temporal-proto/errordetails"
+	"go.temporal.io/temporal-proto/failure"
 	"go.temporal.io/temporal-proto/serviceerror"
 	"go.temporal.io/temporal-proto/workflowservice"
 	"go.temporal.io/temporal-proto/workflowservicemock"
@@ -351,7 +351,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Success() {
 
 func (s *workflowRunSuite) TestExecuteWorkflowWorkflowExecutionAlreadyStartedError() {
 	st, err := status.New(codes.AlreadyExists, "Already Started").
-		WithDetails(&errordetails.WorkflowExecutionAlreadyStartedFailure{RunId: runID})
+		WithDetails(&failure.WorkflowExecutionAlreadyStarted{RunId: runID})
 	s.NoError(err)
 
 	s.workflowServiceClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any()).


### PR DESCRIPTION
Renamed in temporal-proto and temporal-proto-go already. This is just to sync these changes.