### PR TITLE
Fix getFunctionName

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1540,10 +1540,10 @@ func isError(inType reflect.Type) bool {
 }
 
 func getFunctionName(i interface{}) string {
-	fullName, ok := i.(string)
-	if !ok {
-		fullName = runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+	if fullName, ok := i.(string); ok {
+		return fullName
 	}
+	fullName := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 	elements := strings.Split(fullName, ".")
 	return elements[len(elements)-1]
 }


### PR DESCRIPTION
If `i` is a string already, it should be used as is.